### PR TITLE
Fixed SYTEM_INFO structure for 64bit

### DIFF
--- a/WinAPILib/WinAPILib/SystemInfo.xojo_code
+++ b/WinAPILib/WinAPILib/SystemInfo.xojo_code
@@ -160,10 +160,12 @@ Protected Class SystemInfo
 
 
 	#tag Structure, Name = SYSTEM_INFO, Flags = &h0
-		dwPageSize As UInt32
+		wProcessorArchitecture As UInt16
+		  wReserved As UInt16
+		  dwPageSize As UInt32
 		  lpMinimumApplicationAddress As Ptr
 		  lpMaximumApplicationAddress As Ptr
-		  dwActiveProcessorMask As UInt64
+		  dwActiveProcessorMask As UInteger
 		  dwNumberOfProcessors As UInt32
 		  dwProcessorType As UInt32
 		  dwAllocationGranularity As UInt32


### PR DESCRIPTION
This was only working in 32bit prior to this fix.

UInt64 happened to work in 32bit as two WORDs were missing making it look like everything was ok when reading dwNumberOfProcessors

DWORD_PTR should be a UInteger as it changes in size depending on architecture.

See https://blog.samphire.net/2017/01/22/windows-to-xojo-data-type-conversion/ for more information.